### PR TITLE
add SSO configuration for grafana

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -505,6 +505,25 @@ spec:
       size: 10G #FIXME
       storageClassName: TO_BE_FIXED
     grafana.ini:
+      auth:
+        oauth_auto_login: true
+        disable_login_form: true
+        disable_signout_menu: true
+      auth.generic_oauth:
+        enabled: true
+        name: keycloakOAuth
+        client_id: grafana
+        client_secret: TO_BE_FIXED #from keycloak
+        scopes: openid profile email
+        auth_url: TO_BE_FIXED #http://{KEYCLOAK_URL}/auth/realms/{GRAFANA_REALM}/protocol/openid-connect/auth
+        token_url: TO_BE_FIXED #http://{KEYCLOAK_URL}/auth/realms/{GRAFANA_REALM}/protocol/openid-connect/token
+        api_url: TO_BE_FIXED #http://{KEYCLOAK_URL}/auth/realms/{GRAFANA_REALM}/protocol/openid-connect/userinfo
+      server:
+        root_url: TO_BE_FIXED #grafana full URL accessible from browser
+      security:
+        cookie_secure: false #set to true if you host grafana behind HTTPS
+      user:
+        auto_assign_org: true #automatically add new users to the main organization
       plugins:
         vonage-status-panel: true
         grafana-piechart-panel: true

--- a/lma/base/site-values.yaml
+++ b/lma/base/site-values.yaml
@@ -116,6 +116,13 @@ charts:
   override:
     adminPassword: password
     persistence.storageClassName: $(storageClassName)
+    auth.generic_oauth.client_secret: TO_BE_FIXED #from keycloak
+    auth.generic_oauth.scopes: openid profile email
+    auth.generic_oauth.auth_url: TO_BE_FIXED #http://{KEYCLOAK_URL}/auth/realms/{GRAFANA_REALM}/protocol/openid-connect/auth
+    auth.generic_oauth.token_url: TO_BE_FIXED #http://{KEYCLOAK_URL}/auth/realms/{GRAFANA_REALM}/protocol/openid-connect/token
+    auth.generic_oauth.api_url: TO_BE_FIXED #http://{KEYCLOAK_URL}/auth/realms/{GRAFANA_REALM}/protocol/openid-connect/userinfo
+    server.root_url: TO_BE_FIXED #grafana full URL accessible from browser
+    security.cookie_secure: false #set to true if you host grafana behind HTTPS
 
 - name: fluentbit-operator
   override:


### PR DESCRIPTION
Keycloak과 연동하여 SSO를 구현하기 위한 grafana 차트 설정 override

관련이슈: https://app.zenhub.com/workspaces/decapod-development- 610b462a1b6463000f3d3a5a/issues/openinfradev/decapod-issues/6